### PR TITLE
Replace play-services with play-services-analytics and bump version.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.gms:play-services:9.0.0'
+    compile 'com.google.android.gms:play-services-analytics:9.0.1'
     compile 'com.android.support:appcompat-v7:23.4.0'
 }


### PR DESCRIPTION
No need to include play-services in its entirety; only analytics is being used.

Update play-services-analytics to the latest version (9.0.1).

@pfrisella / @philipwalton - please CR.  Thanks!
